### PR TITLE
disabled background playing

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -1557,12 +1557,12 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public void onHostResume() {
-      // do nothing
+      super.onResume();
     }
 
     @Override
     public void onHostPause() {
-      // do nothing
+      super.onPause();
     }
 
     @Override


### PR DESCRIPTION
- app is getting rejected from Google Play store because of "Device and Network abuse" issue.
  - means that youtube video can be played when the app is background
- therefore, disabled background playing.